### PR TITLE
fixed the send bug in speech recognition

### DIFF
--- a/view/app-jarvis.js
+++ b/view/app-jarvis.js
@@ -1,3 +1,4 @@
+/* eslint-disable linebreak-style */
 /* eslint-disable no-console */
 // eslint-disable-next-line no-undef
 const app = angular.module('jarvis', ['ngRoute']),
@@ -146,14 +147,13 @@ app.controller('MainController', function($scope,$location,$rootScope,$http) {
 							submessage = text.substring(m+12);
 							mess.value = submessage;
 							$scope.message = submessage; 
-						}
-	
-						if (text.endsWith('send')) {
-							mess.value = text;
-							n = mess.value.lastIndexOf('send');
-							submessage =  mess.value.substring(m+12,n);
-							$scope.message = submessage;
-							$scope.addMessagesToStack();
+							if (text.endsWith('send')) {
+								mess.value = text;
+								n = mess.value.lastIndexOf('send');
+								submessage =  mess.value.substring(m+12,n);
+								$scope.message = submessage;
+								$scope.addMessagesToStack();
+							}
 						} 
 					} else {
 						text += event.results[i][0].transcript;
@@ -165,7 +165,7 @@ app.controller('MainController', function($scope,$location,$rootScope,$http) {
 						}
 					}
 				}
-			} else {
+			} else if (check === 1) {
 				for (i = 0; i < event.results.length; i++) {
 					if (event.results[i].isFinal) {
 						mess.value += event.results[i][0].transcript;


### PR DESCRIPTION
The speech recognition activates automatically only on speaking **start jarvis**. The bug related to the **send** keyword is being fixed i.e., it won't send the message if the service is not started.

The link to the sample video: [https://drive.google.com/file/d/1sjJtigzS_Z8EPygNS9y9UbTSzVBupb8x/view](https://drive.google.com/file/d/1sjJtigzS_Z8EPygNS9y9UbTSzVBupb8x/view)