### PR TITLE
Corrected empty messages while using google, yahoo, bing, youtube and image searches

### DIFF
--- a/service/controllers/messages.go
+++ b/service/controllers/messages.go
@@ -92,9 +92,15 @@ func routes(routeObject response, w http.ResponseWriter) {
 	// single word operations
 
 	if Connected() {
-		if strings.ToLower(firstPars) == "google" { // for google search
 
-			query := "https://www.google.co.in/search?q=" + messageExceptFirstPars
+		if strings.ToLower(firstPars) == "google" { // for google search
+			query := ""
+			if len(messageExceptFirstPars) == 0 {
+				query = "https://www.google.co.in/search?q=google"
+			} else {
+				query = "https://www.google.co.in/search?q=" + messageExceptFirstPars
+			}
+				 
 			result := HandlerGoogle("GET", query)
 
 			// processing
@@ -110,7 +116,13 @@ func routes(routeObject response, w http.ResponseWriter) {
 			TextToSpeech(responseJSON.Message, 0)
 
 		} else if strings.ToLower(firstPars) == "yahoo" {
-			query := "https://in.search.yahoo.com/search?p=" + messageExceptFirstPars
+			query := ""
+			if len(messageExceptFirstPars) == 0 {
+				query = "https://in.search.yahoo.com/search?p=yahoo"
+			} else {
+				query = "https://in.search.yahoo.com/search?p=" + messageExceptFirstPars
+			}
+
 			result := HandlerYahoo("GET", query)
 
 			// processing
@@ -126,7 +138,13 @@ func routes(routeObject response, w http.ResponseWriter) {
 			TextToSpeech(responseJSON.Message, 0)
 
 		} else if strings.ToLower(firstPars) == "bing" {
-			query := "https://www.bing.com/search?q=" + messageExceptFirstPars
+			query := ""
+			if len(messageExceptFirstPars) == 0 {
+				query = "https://www.bing.com/search?q=bing"
+			} else {
+				query = "https://www.bing.com/search?q=" + messageExceptFirstPars
+			}
+
 			result := HandlerBing("GET", query)
 
 			// processing
@@ -142,7 +160,13 @@ func routes(routeObject response, w http.ResponseWriter) {
 			TextToSpeech(responseJSON.Message, 0)
 
 		} else if strings.ToLower(firstPars) == "youtube" {
-			query := "https://www.youtube.com/results?search_query=" + messageExceptFirstPars
+			query := ""
+			if len(messageExceptFirstPars) == 0 {
+				query = "https://www.youtube.com/results?search_query=youtube"
+			} else {
+				query = "https://www.youtube.com/results?search_query=" + messageExceptFirstPars
+			}
+			 
 			result := HandlerYoutube("GET", query)
 
 			// processing
@@ -158,7 +182,13 @@ func routes(routeObject response, w http.ResponseWriter) {
 			TextToSpeech(responseJSON.Message, 0)
 
 		} else if strings.ToLower(firstPars) == "image" {
-			query := "https://www.google.co.in/search?q="+messageExceptFirstPars+"&source=lnms&tbm=isch"
+			query := ""
+			if len(messageExceptFirstPars) == 0 {
+				query = "https://www.google.co.in/search?q="+"images"+"&source=lnms&tbm=isch"
+			} else {
+				query = "https://www.google.co.in/search?q="+messageExceptFirstPars+"&source=lnms&tbm=isch"
+			}
+			
 			result := HandlerImage("GET", query)
 			// processing
 

--- a/service/controllers/messages.go
+++ b/service/controllers/messages.go
@@ -204,19 +204,22 @@ func routes(routeObject response, w http.ResponseWriter) {
 
 		} else if strings.ToLower(firstPars) == "weather" {
 
-			city := messageArr[len(messageArr)-2]
-			state := messageArr[len(messageArr)-1]
-			result := HandlerWeather(city, state)
-			stringified, _ := json.Marshal(processWeather(result))
-			response := jsonResponseWeather{
-				Status: true,
-				Message: "here are the current weather conditions",
-				Result: string(stringified),
+			if len(messageArr) == 1 || len(messageArr) < 3 {
+				w.Write([]byte(`{"status": "success", "message": "ENTER: weather <city> <state>", "result": ""}`))
+			} else {
+				city := messageArr[len(messageArr)-2]
+				state := messageArr[len(messageArr)-1]
+				result := HandlerWeather(city, state)
+				stringified, _ := json.Marshal(processWeather(result))
+				response := jsonResponseWeather{
+					Status: true,
+					Message: "here are the current weather conditions",
+					Result: string(stringified),
+				}
+				jData, _ := json.Marshal(response)
+				w.Write(jData)
+				TextToSpeech(response.Message + city + " " + state, 0)
 			}
-			jData, _ := json.Marshal(response)
-			w.Write(jData)
-			TextToSpeech(response.Message + city + " " + state, 0)
-
 		} else {
 			// general conversation
 			w.Write([]byte(`{"status": "success", "message": "Hi from reply bot", "result": ""}`))

--- a/view/components/main.html
+++ b/view/components/main.html
@@ -105,6 +105,18 @@
                         </span>
                     </div>
                 </div>
+                <div data-ng-if="message.sender === 'jarvis-bot' && message.message === 'ENTER: weather <city> <state>'" class="chat-screen-messages-jarvis-bot" class="clearfix">
+                    <!-- for displaying error message -->
+                    <div>
+                        {{message.message}}
+                        <span>
+                            <sub class="show-user-creds">
+                                {{message.sender}}
+                                {{message.time}}
+                            </sub>
+                        </span>
+                    </div>
+                </div>
                 <br>
             </div>
         </div>


### PR DESCRIPTION
Fixes: #74 
When user types `google`, `yahoo`, `bing`, `YouTube` and `image` without a query, default search results of each is produced.

![emp2](https://user-images.githubusercontent.com/40494926/55642883-549ebc00-57ef-11e9-9d57-10b2385c7ed8.png)

![emp1](https://user-images.githubusercontent.com/40494926/55643163-15bd3600-57f0-11e9-85dd-da14945339f5.png)

