### PR TITLE
Added general template for displaying messages

### DIFF
--- a/view/components/main.html
+++ b/view/components/main.html
@@ -16,115 +16,102 @@
                         </sub>
                     </span>
                 </div>
-                <div data-ng-if="(message.sender === 'jarvis-bot' && message.message === 'Hi from reply bot') || (message.sender === 'jarvis-bot' && message.show)"
-                 class="chat-screen-messages-jarvis-bot" class="clearfix">
-                    <!-- for simple conversation messages -->
-                    <div>
-                        {{message.message}}
-                        <span>
-                            <sub class="show-user-creds">
-                                {{message.sender}}
-                                {{message.time}}
-                            </sub>
-                        </span>
-                    </div>
-                </div>
-                <div data-ng-if="message.sender === 'jarvis-bot' && message.message === 'here are the top search results'" class="chat-screen-messages-jarvis-bot" class="clearfix">
-                    <div class="message-style">
-                        {{message.message}}
-                        <span>
-                            <sub class="show-user-creds">
-                                {{message.sender}}
-                                {{message.time}}
-                            </sub>
-                        </span>
-                    </div>
-                    <div id="queried-data" data-ng-if="message.result.length !== 0">
-                        <br>
-                        <div data-ng-repeat="objectQuery in message.result" id="queried-info">
-                            <h4 class="head-query-data">{{$index + 1}}. {{objectQuery.head}}</h4>
-                            <a href="{{objectQuery.link}}" target="_blank">{{objectQuery.link}}</a>
-                        </div>
-                    </div>
-                </div>
-                <div data-ng-if="message.sender === 'jarvis-bot' && message.message === 'here are the searched images'" class="chat-screen-messages-jarvis-bot" class="clearfix">
-                    <div class="message-style">
-                        {{message.message}}
-                        <span>
-                            <sub class="show-user-creds">
-                                {{message.sender}}
-                                {{message.time}}
-                            </sub>
-                        </span>
-                    </div>
-                    <div id="queried-data" data-ng-if="message.result.length !== 0">
-                        <div class="images-searched">
-                            <div data-ng-repeat="objectQuery in message.result" id="queried-image">
-                                <div class="item">
-                                    <a href="{{objectQuery.link}}" target="_blank">
-                                        <img ng-src="{{objectQuery.link}}" style="display:block;margin-left: 20px;
-                                        margin-right:20px;padding-right: 10px;width:424.66px;height: 318.48px;" />
-                                    </a>
+
+                <div data-ng-if="message.sender === 'jarvis-bot'" class="chat-screen-messages-jarvis-bot" class="clearfix">
+                    
+                    <div ng-switch="message.message">
+                        <!-- for specific messages -->
+
+                        <div ng-switch-when="here are the top search results">
+                            <div class="message-style">
+                                {{message.message}}
+                                   <span>
+                                    <sub class="show-user-creds">
+                                        {{message.sender}}
+                                        {{message.time}}
+                                    </sub>
+                                </span>
+                            </div>
+                            <div id="queried-data" data-ng-if="message.result.length !== 0">
+                                <br>
+                                <div data-ng-repeat="objectQuery in message.result" id="queried-info">
+                                    <h4 class="head-query-data">{{$index + 1}}. {{objectQuery.head}}</h4>
+                                    <a href="{{objectQuery.link}}" target="_blank">{{objectQuery.link}}</a>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </div>
+                        
 
-                <div data-ng-if="message.sender === 'jarvis-bot' && message.message === 'here are the current weather conditions'"
-                    class="chat-screen-messages-jarvis-bot" class="clearfix">
-                    <div class="message-style">
-                        {{message.message}} at {{message.result.city}}
-                        <span>
-                            <sub class="show-user-creds">
-                                {{message.sender}}
-                                {{message.time}}
-                            </sub>
-                        </span>
-                    </div>
-                    <div id="queried-data" data-ng-if="message.result.length !== 0">
-                        <br>
-                        <div>
-                            <span class="head-query-data">Currently {{message.result.temperature}} &deg;C</span><br>
-                            <span class="head-query-data">Feels like {{message.result.feels_like}} &deg;C</span><br>
-                            <span class="head-query-data">Humidity being {{message.result.humidity}}</span><br>
-                            <span class="head-query-data">Visibility {{message.result.visibility}}</span><br>
-                            <span class="head-query-data">Dew Point {{message.result.dew_point}}</span><br>
-                            <span class="head-query-data">At time {{message.result.time}}</span>
+                        <div ng-switch-when="here are the searched images">
+                            <div class="message-style">
+                                {{message.message}}
+                                <span>
+                                    <sub class="show-user-creds">
+                                        {{message.sender}}
+                                        {{message.time}}
+                                    </sub>
+                                </span>
+                            </div>
+                            <div id="queried-data" data-ng-if="message.result.length !== 0">
+                                <div class="images-searched">
+                                    <div data-ng-repeat="objectQuery in message.result" id="queried-image">
+                                        <div class="item">
+                                            <a href="{{objectQuery.link}}" target="_blank">
+                                            <img ng-src="{{objectQuery.link}}" style="display:block;margin-left: 20px;
+                                                        margin-right:20px;padding-right: 10px;width:424.66px;height: 318.48px;" />
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         </div>
+
+                        <div ng-switch-when="here are the current weather conditions">
+                            <div class="message-style">
+                                {{message.message}} at {{message.result.city}}
+                                <span>
+                                    <sub class="show-user-creds">
+                                        {{message.sender}}
+                                        {{message.time}}
+                                    </sub>
+                                </span>
+                            </div>
+                            <div id="queried-data" data-ng-if="message.result.length !== 0">
+                                <br>
+                                <div>
+                                    <span class="head-query-data">Currently {{message.result.temperature}} &deg;C</span><br>
+                                    <span class="head-query-data">Feels like {{message.result.feels_like}} &deg;C</span><br>
+                                    <span class="head-query-data">Humidity being {{message.result.humidity}}</span><br>
+                                    <span class="head-query-data">Visibility {{message.result.visibility}}</span><br>
+                                    <span class="head-query-data">Dew Point {{message.result.dew_point}}</span><br>
+                                    <span class="head-query-data">At time {{message.result.time}}</span>
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- for general messages -->
+                        <div ng-switch-default>
+                            <div>
+                                {{message.message}}
+                                <span>
+                                    <sub class="show-user-creds">
+                                        {{message.sender}}
+                                        {{message.time}}
+                                    </sub>
+                                </span>
+                            </div>
+                        </div>
+                        
                     </div>
                 </div>
-                <div data-ng-if="message.sender === 'jarvis-bot' && message.message === 'Services unavailable at the moment ! Check your Internet Connection and try again.'" class="chat-screen-messages-jarvis-bot" class="clearfix">
-                    <!-- for displaying error message -->
-                    <div>
-                        {{message.message}}
-                        <span>
-                            <sub class="show-user-creds">
-                                {{message.sender}}
-                                {{message.time}}
-                            </sub>
-                        </span>
-                    </div>
-                </div>
-                <div data-ng-if="message.sender === 'jarvis-bot' && message.message === 'ENTER: weather <city> <state>'" class="chat-screen-messages-jarvis-bot" class="clearfix">
-                    <!-- for displaying error message -->
-                    <div>
-                        {{message.message}}
-                        <span>
-                            <sub class="show-user-creds">
-                                {{message.sender}}
-                                {{message.time}}
-                            </sub>
-                        </span>
-                    </div>
-                </div>
-                <br>
-            </div>
-        </div>
+                <br/>
+            </div>           
+        </div>     
+        
         <!-- message field -->
         <div id="message-bar">
             <div id="message-input-parent">
-                <input type="text" name="" id="message-input" data-ng-model="message" placeholder="Type a message">
+                <input type="text" name="" id="message-input" data-ng-model="message" placeholder="Type a message" autofocus>
                 <button id="message-bar-send" class="btn btn-danger" data-ng-click="addMessagesToStack()">
                     Send
                 </button>
@@ -137,5 +124,5 @@
                     data-ng-click="toggleStartStop()" />
             </div>
         </div>
-    </div>
+</div>
     


### PR DESCRIPTION
Fixes: #78 

With this template, we don't have to manually change `main.html` when we add new General conversations (`message will be displayed by default section of switch-case`).

Adding specific results for chat also made easier as we just have to add a new case in the switch-case structure.

`The display and working of chat remains unaffected.` 

Also added `autofocus` to chat input.